### PR TITLE
add auto_write option to get_ecoinvent

### DIFF
--- a/eidl/core.py
+++ b/eidl/core.py
@@ -117,7 +117,7 @@ def check_requirements():
             return False
 
 
-def get_ecoinvent(db_name=None, *args, **kwargs):
+def get_ecoinvent(db_name=None, auto_write=False, *args, **kwargs):
     if check_requirements():
         with tempfile.TemporaryDirectory() as td:
             downloader = EcoinventDownloader(*args, outdir=td, **kwargs)
@@ -128,11 +128,17 @@ def get_ecoinvent(db_name=None, *args, **kwargs):
             datasets_path = os.path.join(td, 'datasets')
             importer = bw.SingleOutputEcospold2Importer(datasets_path, db_name)
             importer.apply_strategies()
-            importer.statistics()
-            print('\nWrite database {} in project {}?'.format(
+            datasets, exchanges, unlinked = importer.statistics()
+
+            if auto_write and not unlinked:
+                print('\nWriting database {} in project {}'.format(
                 db_name, bw.projects.current))
-            if input('[y]/n ') in {'y', ''}:
                 importer.write_database()
+            else:
+                print('\nWrite database {} in project {}?'.format(
+                    db_name, bw.projects.current))
+                if input('[y]/n ') in {'y', ''}:
+                    importer.write_database()
 
 
 def get_ecoinvent_cli():


### PR DESCRIPTION
Hi Adrian,

This is an excellent and extremely useful utility for Brightway!

Just a small pull request to add an option to automatically write the database (if there are no unlinked processes), without asking the user.

I think `eidl` would be a really good way to make setting up `lcopt` to speak to Brightway foolproof by forcing the user to download and *install* the 'right' version of ecoinvent. Adding the `auto_write` option allows a partial function to do it on one go. e.g.:

```python
from functools import partial

auto_ecoinvent = partial(eidl.get_ecoinvent, db_name='Ecoinvent3_3_cutoff', auto_write=True, version='3.3', system_model='cutoff')

auto_ecoinvent(username='username', password='password') # password can be encrypted environment variable for CI testing

#or just

auto_ecoinvent() # and enter credentials when prompted
```