### PR TITLE
allow specified path to download .7z file to

### DIFF
--- a/eidl/core.py
+++ b/eidl/core.py
@@ -12,7 +12,7 @@ import brightway2 as bw
 
 class EcoinventDownloader:
     def __init__(self, username=None, password=None, version=None,
-                 system_model=None, outdir=None):
+                 system_model=None, outdir=None, **kwargs):
         if username and password:
             self.username = username
             self.password = password
@@ -118,27 +118,45 @@ def check_requirements():
 
 
 def get_ecoinvent(db_name=None, auto_write=False, *args, **kwargs):
+    """
+    Download and import ecoinvent to current brightway2 project
+    Optional kwargs:
+        db_name: name to give imported database (string) default is downloaded filename
+        auto_write: automatically write database if no unlinked processes (boolean) default is False (i.e. prompt yes or no)
+        download_path: path to download .7z file to (string) default is download to temporary directory (.7z file is deleted after import)
+    """
     if check_requirements():
+
         with tempfile.TemporaryDirectory() as td:
-            downloader = EcoinventDownloader(*args, outdir=td, **kwargs)
+
+            if 'download_path' in kwargs:
+                download_path = kwargs['download_path']
+            else:
+                download_path = td
+
+            print("downloading to {}".format(download_path))
+
+            downloader = EcoinventDownloader(*args, outdir=download_path, **kwargs)
+
             extract = '7za x {} -o{}'.format(downloader.out_path, td)
             subprocess.call(extract.split())
             if not db_name:
                 db_name = downloader.file_name.replace('.7z', '')
             datasets_path = os.path.join(td, 'datasets')
             importer = bw.SingleOutputEcospold2Importer(datasets_path, db_name)
-            importer.apply_strategies()
-            datasets, exchanges, unlinked = importer.statistics()
 
-            if auto_write and not unlinked:
-                print('\nWriting database {} in project {}'.format(
+        importer.apply_strategies()
+        datasets, exchanges, unlinked = importer.statistics()
+
+        if auto_write and not unlinked:
+            print('\nWriting database {} in project {}'.format(
+            db_name, bw.projects.current))
+            importer.write_database()
+        else:
+            print('\nWrite database {} in project {}?'.format(
                 db_name, bw.projects.current))
+            if input('[y]/n ') in {'y', ''}:
                 importer.write_database()
-            else:
-                print('\nWrite database {} in project {}?'.format(
-                    db_name, bw.projects.current))
-                if input('[y]/n ') in {'y', ''}:
-                    importer.write_database()
 
 
 def get_ecoinvent_cli():


### PR DESCRIPTION
Add the ability to specify a `download_path` to `get_ecoinvent` as an optional kwarg

This could be a first step towards a solution for #6. 

I've stopped short of specifying an `appdirs` directory though, mainly because for my use case I want to store the .7z files in an lcopt system directory so if you change the name of your single project (or delete one of your setup projects), you can use a predownloaded .7z file to import ecoinvent.

