### PR TITLE
Astunparse now supports 3.7

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,11 +17,11 @@ build:
 
 requirements:
   build:
-    - python<3.7
+    - python<3.8
     - setuptools
-    
+
   run:
-    - python<3.7
+    - python<3.8
     - brightway2
     - requests
     - beautifulsoup4
@@ -38,5 +38,5 @@ about:
   license_family: MIT
   summary: EcoInventDownLoader (eidl)
   description: |
-    Download, unpack and import ecoinvent into your brightway2 project in one simple step. 
+    Download, unpack and import ecoinvent into your brightway2 project in one simple step.
     More details and installation instructions can be found on [github](https://github.com/haasad/EcoInventDownLoader)


### PR DESCRIPTION
See [here](https://github.com/simonpercivall/astunparse/blob/master/HISTORY.rst#160---2018-09-30).

Merging this will make the path fix accessible for anaconda python 3.7 users.