### PR TITLE
Replace eidl7zip with py7zr

### DIFF
--- a/.github/environment-build.yaml
+++ b/.github/environment-build.yaml
@@ -2,7 +2,6 @@ name: build
 channels:
   - conda-forge
   - cmutel
-  - haasad
 dependencies:
   - conda-build
   - anaconda-client

--- a/.github/environment-test.yaml
+++ b/.github/environment-test.yaml
@@ -2,10 +2,9 @@ name: test
 channels:
   - conda-forge
   - cmutel
-  - haasad
 dependencies:
   - brightway2
   - requests
   - beautifulsoup4
-  - eidl7zip
+  - py7zr
   - flake8

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -25,7 +25,7 @@ requirements:
     - brightway2
     - requests
     - beautifulsoup4
-    - eidl7zip
+    - py7zr
     - appdirs
 
 test:

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "eidl" %}
-{% set version = "1.3.3" %}
+{% set version = "1.4.0" %}
 
 package:
   name: {{ name|lower }}

--- a/eidl/core.py
+++ b/eidl/core.py
@@ -154,7 +154,7 @@ class EcoinventDownloader:
             out_file.write(file_content)
 
     def extract(self, target_dir):
-        extract_cmd = ['7za', 'x', self.out_path, '-o{}'.format(target_dir)]
+        extract_cmd = ['py7zr', 'x', self.out_path, target_dir]
         try:
             self.extraction_process = subprocess.Popen(extract_cmd)
             self.extraction_process.wait()

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 setup(
     name='eidl',
     packages=['eidl'],
-    version='1.3.3',
+    version='1.4.0',
     author="Adrian Haas",
     url="https://github.com/haasad/EcoInventDownLoader",
     license=open('LICENSE').read(),


### PR DESCRIPTION
[py7zr](https://github.com/miurahr/py7zr) is a python package to work with 7zip archives. This replaces the old work-around of using CI tools to package 7zip command line tools for all operating systems that, see https://github.com/haasad/eidl7zip

See also https://github.com/LCA-ActivityBrowser/activity-browser/issues/705