### PR TITLE
Small adaption of the extract function for the activity-browser

### DIFF
--- a/eidl/core.py
+++ b/eidl/core.py
@@ -153,11 +153,11 @@ class EcoinventDownloader:
         with open(self.out_path, 'wb') as out_file:
             out_file.write(file_content)
 
-    def extract(self, target_dir):
+    def extract(self, target_dir, **kwargs):
         extract_cmd = ['py7zr', 'x', self.out_path, target_dir]
         try:
-            self.extraction_process = subprocess.Popen(extract_cmd)
-            self.extraction_process.wait()
+            self.extraction_process = subprocess.Popen(extract_cmd, **kwargs)
+            return self.extraction_process.wait()
         except FileNotFoundError as e:
             if "PYCHARM_HOSTED" in os.environ:
                 print('It appears the EcoInventDownLoader is run from PyCharm. ' +


### PR DESCRIPTION
Pass kwargs to subprocess and return the returncode. This is used in the Activity-Browser for subclassing the extraction function

see https://github.com/LCA-ActivityBrowser/activity-browser/issues/737