### PR TITLE
Add compatibility with brightway25

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The EcoInventDownLoader (eidl) is a small python package that automates the some
 - Login to the ecoinvent homepage
 - Choose and download the required database
 - Unpack the 7z-archive on your computer (which will take up close to 2GB of disk space)
-- Import the ecospold2 files with the `brightway2.SingleOutputEcospoldImporter`
+- Import the ecospold2 files with the `bw2io.SingleOutputEcospoldImporter`
 
 With `eidl`, the above steps can all be carried out with a single command from a jupyter notebook or any python shell:
 ```

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -20,7 +20,8 @@ requirements:
 
   run:
     - python
-    - brightway2
+    - bw2io
+    - bw2data
     - requests
     - beautifulsoup4
     - py7zr

--- a/eidl/core.py
+++ b/eidl/core.py
@@ -6,7 +6,8 @@ import subprocess
 
 import requests
 import bs4
-import brightway2 as bw
+from bw2io import SingleOutputEcospold2Importer, bw2setup
+from bw2data import projects, databases
 
 from eidl.storage import eidlstorage
 
@@ -195,17 +196,17 @@ def get_ecoinvent(db_name=None, auto_write=False, download_path=None, store_down
         if not db_name:
             db_name = downloader.file_name.replace('.7z', '')
         datasets_path = os.path.join(td, 'datasets')
-        importer = bw.SingleOutputEcospold2Importer(datasets_path, db_name)
+        importer = SingleOutputEcospold2Importer(datasets_path, db_name)
 
-    if 'biosphere3' not in bw.databases:
+    if 'biosphere3' not in databases:
         if auto_write:
-            bw.bw2setup()
+            bw2setup()
         else:
             print('No biosphere database present in your current ' +
-                  'project: {}'.format(bw.projects.current))
+                  'project: {}'.format(projects.current))
             print('You can run "bw2setup()" if this is a new project. Run it now?')
             if input('[y]/n ') in {'y', ''}:
-                bw.bw2setup()
+                bw2setup()
             else:
                 return
 
@@ -214,11 +215,11 @@ def get_ecoinvent(db_name=None, auto_write=False, download_path=None, store_down
 
     if auto_write and not unlinked:
         print('\nWriting database {} in project {}'.format(
-            db_name, bw.projects.current))
+            db_name, projects.current))
         importer.write_database()
     else:
         print('\nWrite database {} in project {}?'.format(
-            db_name, bw.projects.current))
+            db_name, projects.current))
         if input('[y]/n ') in {'y', ''}:
             importer.write_database()
 


### PR DESCRIPTION
With brightway25 we can no longer "from brightway25 import ...", instead import directly from sub-packages.

I replaced "import from brightway2" by imports from "bw2data" and "bw2io" in core.py ; modifications are also applied to files readme.md and conda-recipe/meta.yaml