### PR TITLE
Exclude files that user is not allowed to download

### DIFF
--- a/eidl/core.py
+++ b/eidl/core.py
@@ -97,9 +97,11 @@ class EcoinventDownloader:
             self.handle_connection_timeout()
             raise e
         soup = bs4.BeautifulSoup(files_res.text, 'html.parser')
-        file_list = [l for l in soup.find_all('a', href=True) if
+        all_files = [l for l in soup.find_all('a', href=True) if
                      l['href'].startswith('/File/File?')]
-        link_dict = {f.contents[0]: f['href'] for f in file_list}
+        not_allowed = soup.find_all('a',  class_='fileDownloadNotAllowed')
+        available_files = set(all_files).difference(set(not_allowed))
+        link_dict = {f.contents[0]: f['href'] for f in available_files}
         link_dict = {
             k.replace('-', ''):v for k, v in link_dict.items() if k.startswith('ecoinvent ') and
             k.endswith('ecoSpold02.7z') and not 'lc' in k.lower()


### PR DESCRIPTION
Based on the type of ecoinvent license, not all files are actually
available to download even though they're listed in the page source.
Files with the html class `fileDownloadNotAllowed` are now excluded.

Related activity-browser issue: https://github.com/LCA-ActivityBrowser/activity-browser/issues/775