### PR TITLE
Drop beautifulsoup4, not used anymore with the new ecoinvent site

### DIFF
--- a/.github/environment-build.yaml
+++ b/.github/environment-build.yaml
@@ -1,7 +1,6 @@
 name: build
 channels:
   - conda-forge
-  - cmutel
 dependencies:
   - conda-build
   - anaconda-client

--- a/.github/environment-test.yaml
+++ b/.github/environment-test.yaml
@@ -1,10 +1,8 @@
 name: test
 channels:
   - conda-forge
-  - cmutel
 dependencies:
   - brightway2
   - requests
-  - beautifulsoup4
   - py7zr
   - flake8

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     - bw2io
     - bw2data
     - requests
-    - beautifulsoup4
     - py7zr
     - appdirs
 

--- a/eidl/core.py
+++ b/eidl/core.py
@@ -6,7 +6,6 @@ import subprocess
 import json
 
 import requests
-import bs4
 from bw2io import SingleOutputEcospold2Importer, bw2setup
 from bw2data import projects, databases
 


### PR DESCRIPTION
Also drop the cmutel channel in the build and test envs, brightway2 packages are available on conda-forge.